### PR TITLE
Issue 11 -Fix for ssh exec on windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: java
+jdk:
+  - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: java

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: java
+script: "mvn install -DskipTests=true -Dmaven.javadoc.skip=true"
 jdk:
   - oraclejdk8

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,13 @@
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-ssh</artifactId>
-      <version>2.11-SNAPSHOT</version>
+      <version>2.12</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>plexus-component-api</artifactId>
+          <groupId>org.codehaus.plexus</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/codehaus/mojo/wagon/SshExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/wagon/SshExecMojo.java
@@ -20,10 +20,10 @@ package org.codehaus.mojo.wagon;
  */
 
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.wagon.CommandExecutor;
 import org.apache.maven.wagon.Streams;
 import org.apache.maven.wagon.Wagon;
 import org.apache.maven.wagon.WagonException;
-import org.apache.maven.wagon.providers.ssh.jsch.ScpWagon;
 
 /**
  * Executes a list of commands against a given server.
@@ -66,7 +66,7 @@ public class SshExecMojo
             {
                 try
                 {
-                    Streams stream = ( (ScpWagon) wagon ).executeCommand( commands[i], true, false );
+                    Streams stream = ( (CommandExecutor) wagon ).executeCommand( commands[i], false );
                     this.getLog().info( "sshexec: " + commands[i] + " ..." );
                     if ( displayCommandOutputs )
                     {


### PR DESCRIPTION
Tracked down the problematic code that only expects ScpWagon to be used for executing SSH commands.

In order to compile with travis-ci, a .travis.yml has been added and pom.xml file updated in order to pass plexus enforcer rules.