### PR TITLE
Allow decryption of proxy passwords.

### DIFF
--- a/src/main/java/org/codehaus/mojo/wagon/shared/DefaultWagonFactory.java
+++ b/src/main/java/org/codehaus/mojo/wagon/shared/DefaultWagonFactory.java
@@ -177,12 +177,14 @@ public class DefaultWagonFactory
      *
      * @return a proxyInfo object or null if no active proxy is define in the settings.xml
      */
-    private static ProxyInfo getProxyInfo( Settings settings )
+    private ProxyInfo getProxyInfo( Settings settings )
     {
         ProxyInfo proxyInfo = null;
         if ( settings != null && settings.getActiveProxy() != null )
         {
-            Proxy settingsProxy = settings.getActiveProxy();
+            SettingsDecryptionResult result =
+                    settingsDecrypter.decrypt( new DefaultSettingsDecryptionRequest( settings.getActiveProxy() ) );
+            Proxy settingsProxy = result.getProxy();
 
             proxyInfo = new ProxyInfo();
             proxyInfo.setHost( settingsProxy.getHost() );


### PR DESCRIPTION
This patch allows decryption of proxy passwords from settings.xml using Maven standard encryption features.
This is needed in environments with authenticated proxies as to avoid storing clear text passwords in settings.xml.