### PR TITLE
Changes to sync from s3 to artifactory

### DIFF
--- a/src/main/java/org/codehaus/mojo/wagon/shared/DefaultWagonDownload.java
+++ b/src/main/java/org/codehaus/mojo/wagon/shared/DefaultWagonDownload.java
@@ -75,6 +75,7 @@ public class DefaultWagonDownload
             String remoteFile = (String) aFileList;
 
             File destination = new File( remoteFileSet.getDownloadDirectory() + "/" + remoteFile );
+            destination.getParentFile().mkdirs();
 
             if ( !StringUtils.isBlank( remoteFileSet.getDirectory() ) )
             {

--- a/src/main/java/org/codehaus/mojo/wagon/shared/DefaultWagonUpload.java
+++ b/src/main/java/org/codehaus/mojo/wagon/shared/DefaultWagonUpload.java
@@ -21,6 +21,7 @@ package org.codehaus.mojo.wagon.shared;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.shared.model.fileset.FileSet;
@@ -51,6 +52,7 @@ public class DefaultWagonUpload
         FileSetManager fileSetManager = new FileSetManager( logger, logger.isDebugEnabled() );
 
         String[] files = fileSetManager.getIncludedFiles( fileset );
+        Arrays.sort(files);
 
         String url = wagon.getRepository().getUrl() + "/";
 


### PR DESCRIPTION
Ensure the local sync directory gets created before downloading files.
Sort the fileset so that artifacts are uploaded before their checksum files