### PR TITLE
 added support for wagon:merge-maven-repos to resolve target from pom distributionManagement

### DIFF
--- a/src/main/java/org/codehaus/mojo/wagon/AbstractCopyMojo.java
+++ b/src/main/java/org/codehaus/mojo/wagon/AbstractCopyMojo.java
@@ -25,6 +25,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.wagon.ConnectionException;
 import org.apache.maven.wagon.Wagon;
 import org.apache.maven.wagon.WagonException;
+import org.codehaus.mojo.wagon.shared.WagonUtils;
 
 public abstract class AbstractCopyMojo
     extends AbstractDoubleWagonMojo
@@ -50,7 +51,7 @@ public abstract class AbstractCopyMojo
         try
         {
             srcWagon = createWagon( sourceId, source );
-            targetWagon = createWagon( targetId, target );
+            targetWagon = createTargetWagon();
             copy( srcWagon, targetWagon );
         }
         catch ( Exception e )
@@ -63,6 +64,20 @@ public abstract class AbstractCopyMojo
             disconnectWagon( targetWagon );
         }
 
+    }
+
+    protected Wagon createTargetWagon() throws MojoExecutionException {
+        Wagon targetWagon;
+        if ( target.contentEquals( "pom" ) )
+        {
+            targetWagon = WagonUtils.createDistributionManagementWagon( wagonFactory, project, settings );
+            getLog().info( "resolving -Dmaven.target=pom to url=" + targetWagon.getRepository().getUrl() );
+        }
+        else
+        {
+            targetWagon = createWagon( targetId, target );
+        }
+        return targetWagon;
     }
 
     private void disconnectWagon( Wagon wagon )

--- a/src/main/java/org/codehaus/mojo/wagon/AbstractDoubleWagonMojo.java
+++ b/src/main/java/org/codehaus/mojo/wagon/AbstractDoubleWagonMojo.java
@@ -36,6 +36,8 @@ public abstract class AbstractDoubleWagonMojo
 
     /**
      * The URL to the target repository.
+     * The special value "pom" can be used to resolve url from pom.xml distributionManagment
+     * (either repository.url or snapshotRepository.url for -SNAPSHOT version)
      */
     @Parameter( property = "wagon.target", required = true)
     protected String target;

--- a/src/main/java/org/codehaus/mojo/wagon/RepositoryDeployMojo.java
+++ b/src/main/java/org/codehaus/mojo/wagon/RepositoryDeployMojo.java
@@ -1,0 +1,89 @@
+package org.codehaus.mojo.wagon;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.wagon.Wagon;
+import org.codehaus.mojo.wagon.shared.MavenRepoMerger;
+import org.codehaus.mojo.wagon.shared.WagonUtils;
+
+/**
+ * Deploy artifacts from a local repository to pom distributionManagement repository.
+ * <p>
+ * This can be used typically after
+ * <PRE>
+ * mvn deploy -DaltDeploymentRepository=local::default::file:./target/staging-deploy
+ * </PRE>
+ */
+@Mojo( name = "repository-deploy" , requiresProject = true)
+public class RepositoryDeployMojo
+    extends AbstractWagonMojo
+{
+
+    /**
+     * The directory of the source repository.
+     */
+    @Parameter( property = "source", required = true)
+    protected String source;
+
+    /**
+     * Optimize the upload by locally compressed all files in one bundle, upload the bundle, and finally remote
+     * uncompress the bundle. This only works with SCP's URL
+     */
+    @Parameter( property = "wagon.optimize", defaultValue = "false")
+    protected boolean optimize = false;
+
+    @Component
+    private MavenRepoMerger mavenRepoMerger;
+
+    @Override
+    public void execute()
+        throws MojoExecutionException
+    {
+        if ( this.skip )
+        {
+            this.getLog().info( "Skip execution." );
+            return;
+        }
+
+        Wagon srcWagon = null;
+        Wagon targetWagon = null;
+        try
+        {
+            srcWagon = createWagon( "default", "file:" + source );
+            targetWagon = WagonUtils.createDistributionManagementWagon( wagonFactory, project, settings );
+
+            mavenRepoMerger.merge( srcWagon, targetWagon, optimize, this.getLog() );
+        }
+        catch ( Exception e )
+        {
+            throw new MojoExecutionException( "Error during performing repository deploy", e );
+        }
+        finally
+        {
+            WagonUtils.disconnectWagon( getLog(), srcWagon );
+            WagonUtils.disconnectWagon( getLog(), targetWagon );
+        }
+    }
+
+}

--- a/src/main/java/org/codehaus/mojo/wagon/shared/WagonUtils.java
+++ b/src/main/java/org/codehaus/mojo/wagon/shared/WagonUtils.java
@@ -1,5 +1,13 @@
 package org.codehaus.mojo.wagon.shared;
 
+import org.apache.maven.model.DeploymentRepository;
+import org.apache.maven.model.DistributionManagement;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.settings.Settings;
+import org.apache.maven.wagon.ConnectionException;
+import org.apache.maven.wagon.Wagon;
 import org.codehaus.plexus.util.StringUtils;
 
 public class WagonUtils
@@ -29,5 +37,63 @@ public class WagonUtils
 
     }
 
+    /**
+     * create Wagon for a pom distributionManagment
+     *
+     * @param wagonFactory
+     * @param project
+     * @param settings
+     * @return
+     * @throws MojoExecutionException
+     */
+    public static  Wagon createDistributionManagementWagon( WagonFactory wagonFactory, 
+                                                            MavenProject project, Settings settings) 
+                    throws MojoExecutionException
+    {
+        DistributionManagement dist = project.getDistributionManagement();
+        if ( dist == null )
+        {
+            throw new MojoExecutionException( "no <distributionManagement> set for using -Dmaven.target=pom" );
+        }
+        boolean isSnapshot = project.getVersion().endsWith("-SNAPSHOT");
+        DeploymentRepository repo = ( isSnapshot )? dist.getSnapshotRepository() : dist.getRepository();
+        String repoId = repo.getId();
+        String url = repo.getUrl();
+        if ( url == null )
+        {
+            String repoTag = ( isSnapshot )? "snapshotRepository" : "repository";
+            throw new MojoExecutionException( "no <distributionManagement><" + repoTag + "><url> set" );
+        }
+        Wagon targetWagon = createWagon( wagonFactory, repoId, url, settings );
+        return targetWagon;
+    }
+
+    public static Wagon createWagon( WagonFactory wagonFactory, String id, String url, Settings settings)
+                    throws MojoExecutionException
+    {
+        try
+        {
+            return wagonFactory.create( url, id, settings );
+        }
+        catch ( Exception e )
+        {
+            throw new MojoExecutionException( "Unable to create a Wagon instance for " + url, e );
+        }
+    }
+
+    public static void disconnectWagon( Log log, Wagon wagon )
+    {
+        try
+        {
+            if ( wagon != null )
+            {
+                wagon.disconnect();
+            }
+        }
+        catch ( ConnectionException e )
+        {
+            log.debug( "Error disconnecting wagon - ignored", e );
+        }
+    }
 
 }


### PR DESCRIPTION
 added support for wagon:merge-maven-repos -Dmaven.target=pom and equivalent mojo 'repository-deploy' to resolve target repository with distributionManagement

cf https://github.com/Arnaud-Nauwynck/test-snippets/tree/master/test-http-repo/src/test/dummy-project