### PR TITLE
Fix download in maven 3.6.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ install: true
 
 jdk:
 #  - openjdk7 (can't use it since some dependencies required java 8)
-  - oraclejdk8
+  - openjdk8
 
 script:
   - mvn clean verify -B -e -V

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
     <takari-plugin-testing.version>2.9.0</takari-plugin-testing.version>
     <takari-lifecycle-plugin.version>1.12.2</takari-lifecycle-plugin.version>
 
+    <ftpserver.version>1.1.1</ftpserver.version>
   </properties>
 
   <repositories>
@@ -238,7 +239,18 @@
       <type>pom</type>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.apache.ftpserver</groupId>
+      <artifactId>ftpserver-core</artifactId>
+      <version>${ftpserver.version}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/org/codehaus/mojo/wagon/shared/WagonDirectoryScanner.java
+++ b/src/main/java/org/codehaus/mojo/wagon/shared/WagonDirectoryScanner.java
@@ -365,14 +365,18 @@ public class WagonDirectoryScanner
             return true;
         }
 
-        return canList(existedRemotePath + "/");
+        return canListPath( existedRemotePath + "/" );
     }
 
-    private boolean canList(String resourceName) {
-        try {
-            List<String> resources = wagon.getFileList(resourceName);
+    private boolean canListPath( String remotePath )
+    {
+        try
+        {
+            List resources = wagon.getFileList( remotePath );
             return resources != null && !resources.isEmpty();
-        } catch (WagonException e) {
+        }
+        catch ( WagonException e )
+        {
             return false;
         }
     }

--- a/src/main/java/org/codehaus/mojo/wagon/shared/WagonDirectoryScanner.java
+++ b/src/main/java/org/codehaus/mojo/wagon/shared/WagonDirectoryScanner.java
@@ -30,9 +30,6 @@ import org.codehaus.plexus.util.StringUtils;
 
 public class WagonDirectoryScanner
 {
-    private final static String[] NOT_DIRECTORIES = new String[] { ".jar", ".zip", ".md5", ".sha1", ".pom", ".xml",
-        ".war" };
-
     /**
      * Patterns which should be excluded by default.
      *
@@ -362,22 +359,22 @@ public class WagonDirectoryScanner
         }
     }
 
-    private boolean isDirectory( String existedRemotePath )
-        throws WagonException
-    {
-        for ( String NOT_DIRECTORY : NOT_DIRECTORIES )
-        {
-            if ( existedRemotePath.endsWith( NOT_DIRECTORY ) )
-            {
-                return false;
-            }
-        }
+    private boolean isDirectory( String existedRemotePath ) {
         if ( existedRemotePath.endsWith( "/" ) )
         {
             return true;
         }
 
-        return wagon.resourceExists( existedRemotePath + "/" );
+        return canList(existedRemotePath + "/");
+    }
+
+    private boolean canList(String resourceName) {
+        try {
+            List<String> resources = wagon.getFileList(resourceName);
+            return resources != null && !resources.isEmpty();
+        } catch (WagonException e) {
+            return false;
+        }
     }
 
     // ///////////////////////////////////////////////////////////////////////////////

--- a/src/test/java/org/codehaus/mojo/wagon/Wagon334MojoHttpTest.java
+++ b/src/test/java/org/codehaus/mojo/wagon/Wagon334MojoHttpTest.java
@@ -1,0 +1,49 @@
+package org.codehaus.mojo.wagon;
+
+import java.io.File;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.takari.maven.testing.TestResources;
+import io.takari.maven.testing.executor.MavenExecution;
+import io.takari.maven.testing.executor.MavenExecutionResult;
+import io.takari.maven.testing.executor.MavenRuntime;
+import io.takari.maven.testing.executor.MavenRuntime.MavenRuntimeBuilder;
+import io.takari.maven.testing.executor.MavenVersions;
+import io.takari.maven.testing.executor.junit.MavenJUnitTestRunner;
+
+@RunWith( MavenJUnitTestRunner.class )
+@MavenVersions( { "3.6.3" } )
+public class Wagon334MojoHttpTest
+{
+    @Rule
+    public final TestResources resources = new TestResources();
+
+    public final MavenRuntime maven;
+
+    public Wagon334MojoHttpTest(MavenRuntimeBuilder builder )
+        throws Exception
+    {
+        this.maven = builder.withCliOptions( "-B" ).build();
+    }
+
+    @Test
+    public void testDownload()
+        throws Exception
+    {
+        // issue: https://github.com/mojohaus/wagon-maven-plugin/issues/39
+        File projDir = resources.getBasedir( "http-download-02" );
+        MavenExecution mavenExec = maven.forProject( projDir );
+
+        MavenExecutionResult result = mavenExec.execute( "clean", "verify" );
+        result.assertErrorFreeLog();
+
+        File downloadDir = new File(result.getBasedir(), "target/it/http-download/");
+        Assert.assertTrue( new File(downloadDir, "commons-dbutils-1.2-bin.tar.gz.asc" ).exists() );
+        Assert.assertTrue( new File(downloadDir, "commons-dbutils-1.2-bin.tar.gz.asc.md5" ).exists() );
+        Assert.assertTrue( new File(downloadDir, "commons-dbutils-1.2-bin.tar.gz.asc.sha1" ).exists() );
+    }
+}

--- a/src/test/java/org/codehaus/mojo/wagon/WagonMojoFtpBasicTest.java
+++ b/src/test/java/org/codehaus/mojo/wagon/WagonMojoFtpBasicTest.java
@@ -2,7 +2,14 @@ package org.codehaus.mojo.wagon;
 
 import java.io.File;
 
+import org.apache.ftpserver.ConnectionConfigFactory;
+import org.apache.ftpserver.FtpServer;
+import org.apache.ftpserver.FtpServerFactory;
+import org.apache.ftpserver.ftplet.FtpException;
+import org.apache.ftpserver.usermanager.impl.BaseUser;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,11 +30,25 @@ public class WagonMojoFtpBasicTest
     public final TestResources resources = new TestResources();
 
     public final MavenRuntime maven;
+    public final FtpServer ftpServer;
 
     public WagonMojoFtpBasicTest( MavenRuntimeBuilder builder )
         throws Exception
     {
+        this.ftpServer = createFtp();
         this.maven = builder.withCliOptions( "-B", "-e", "-s", "settings.xml" ).build();
+    }
+
+    @Before
+    public void setup() throws Exception  {
+        ftpServer.start();
+    }
+
+    @After
+    public void teardown() {
+        if (ftpServer != null && !ftpServer.isStopped()){
+            ftpServer.stop();
+        }
     }
 
     @Test
@@ -38,9 +59,26 @@ public class WagonMojoFtpBasicTest
         MavenExecution mavenExec = maven.forProject( projDir );
         MavenExecutionResult result = mavenExec.execute( "clean", "verify" );
         result.assertErrorFreeLog();
-        Assert.assertTrue( new File( result.getBasedir(), "target/it/README" ).exists() );
-        Assert.assertTrue( new File( result.getBasedir(), "target/it/single-dir/README" ).exists() );
-        Assert.assertTrue( new File( result.getBasedir(), "target/it/single-dir/HEADER.html" ).exists() );
+        Assert.assertTrue( new File( result.getBasedir(), "target/it/WagonMojoFtpBasicTest.class" ).exists() );
+        Assert.assertTrue( new File( result.getBasedir(), "target/it/single-dir/WagonMojoFtpBasicTest.class" ).exists() );
+        Assert.assertTrue( new File( result.getBasedir(), "target/it/single-dir/WagonMojoHttpTest.class" ).exists() );
 
+    }
+
+    private FtpServer createFtp()
+        throws FtpException
+    {
+        FtpServerFactory serverFactory = new FtpServerFactory();
+        ConnectionConfigFactory connectionConfigFactory = new ConnectionConfigFactory();
+        connectionConfigFactory.setAnonymousLoginEnabled( true );
+
+        serverFactory.setConnectionConfig(connectionConfigFactory.createConnectionConfig());
+
+        BaseUser user = new BaseUser();
+        user.setName( "anonymous" );
+        user.setHomeDirectory( new File( "target" ).getAbsolutePath() );
+        serverFactory.getUserManager().save( user );
+
+        return serverFactory.createServer();
     }
 }

--- a/src/test/java/org/codehaus/mojo/wagon/WagonMojoFtpBasicTest.java
+++ b/src/test/java/org/codehaus/mojo/wagon/WagonMojoFtpBasicTest.java
@@ -6,6 +6,7 @@ import org.apache.ftpserver.ConnectionConfigFactory;
 import org.apache.ftpserver.FtpServer;
 import org.apache.ftpserver.FtpServerFactory;
 import org.apache.ftpserver.ftplet.FtpException;
+import org.apache.ftpserver.listener.ListenerFactory;
 import org.apache.ftpserver.usermanager.impl.BaseUser;
 import org.junit.After;
 import org.junit.Assert;
@@ -72,7 +73,11 @@ public class WagonMojoFtpBasicTest
         ConnectionConfigFactory connectionConfigFactory = new ConnectionConfigFactory();
         connectionConfigFactory.setAnonymousLoginEnabled( true );
 
-        serverFactory.setConnectionConfig(connectionConfigFactory.createConnectionConfig());
+        ListenerFactory factory = new ListenerFactory();
+        factory.setPort( 8221 );
+
+        serverFactory.setConnectionConfig( connectionConfigFactory.createConnectionConfig() );
+        serverFactory.addListener( "default", factory.createListener() );
 
         BaseUser user = new BaseUser();
         user.setName( "anonymous" );

--- a/src/test/projects/ftp-basic/pom.xml
+++ b/src/test/projects/ftp-basic/pom.xml
@@ -31,7 +31,7 @@
         <configuration>
           <skip>false</skip>
           <serverId>anonymous.ftp</serverId>
-          <url>ftp://ftp.ibiblio.org</url>
+          <url>ftp://anonymous@localhost/test-classes/org/codehaus/mojo/wagon</url>
         </configuration>
         <executions>
           <execution>
@@ -41,7 +41,7 @@
               <goal>download-single</goal>
             </goals>
             <configuration>
-              <fromFile>pub/linux/devel/vc/README</fromFile>
+              <fromFile>WagonMojoFtpBasicTest.class</fromFile>
               <toDir>${downloadDirectory.base}</toDir>
             </configuration>
           </execution>
@@ -53,7 +53,7 @@
             </goals>
             <configuration>
               <toDir>${downloadDirectory.base}/single-dir</toDir>
-              <includes>README,HEADER.html</includes>
+              <includes>WagonMojoFtpBasicTest.class,WagonMojoHttpTest.class</includes>
             </configuration>
           </execution>
           <execution>

--- a/src/test/projects/ftp-basic/pom.xml
+++ b/src/test/projects/ftp-basic/pom.xml
@@ -31,7 +31,7 @@
         <configuration>
           <skip>false</skip>
           <serverId>anonymous.ftp</serverId>
-          <url>ftp://anonymous@localhost/test-classes/org/codehaus/mojo/wagon</url>
+          <url>ftp://anonymous@localhost:8221/test-classes/org/codehaus/mojo/wagon</url>
         </configuration>
         <executions>
           <execution>

--- a/src/test/projects/http-download-02/pom.xml
+++ b/src/test/projects/http-download-02/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.codehaus.mojo.it</groupId>
+  <artifactId>wagon-maven-plugin.it</artifactId>
+  <packaging>pom</packaging>
+  <version>1.0.0-SNAPSHOT</version>
+
+  <properties>
+    <downloadDirectory.base>${project.build.directory}/it/http-download</downloadDirectory.base>
+    <wagon.api.version>3.3.4</wagon.api.version>
+  </properties>
+
+  <build>
+    <extensions>
+      <extension>
+        <groupId>org.apache.maven.wagon</groupId>
+        <artifactId>wagon-http</artifactId>
+        <version>${wagon.api.version}</version>
+      </extension>
+    </extensions>
+
+    <defaultGoal>package</defaultGoal>
+
+    <finalName>${project.artifactId}</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>wagon-maven-plugin</artifactId>
+        <version>${it-plugin.version}</version>
+        <configuration>
+          <serverId>central</serverId>
+        </configuration>
+        <executions>
+          <execution>
+            <id>http-selective-download-2</id>
+            <phase>package</phase>
+            <goals>
+              <goal>download</goal>
+            </goals>
+            <configuration>
+              <url>https://repo1.maven.org/maven2/commons-dbutils/commons-dbutils/1.2</url>
+              <includes>
+                commons-dbutils-1.2-bin.tar.gz.asc,
+                commons-dbutils-1.2-bin.tar.gz.asc.md5,
+                commons-dbutils-1.2-bin.tar.gz.asc.sha1
+              </includes>
+              <toDir>${downloadDirectory.base}</toDir>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/projects/http-download-02/settings.xml
+++ b/src/test/projects/http-download-02/settings.xml
@@ -1,0 +1,18 @@
+<settings xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd">
+  <localRepository xmlns="http://maven.apache.org/SETTINGS/1.1.0">/tmp/.m2/repository</localRepository>
+  <servers xmlns="http://maven.apache.org/SETTINGS/1.1.0">
+    <server>
+      <id>central</id>
+      <username>jbochenski</username>
+      <password>***</password>
+      <configuration>
+        <httpConfiguration>
+          <all>
+            <usePreemptive>true</usePreemptive>
+          </all>
+        </httpConfiguration>
+      </configuration>
+    </server>
+  </servers>
+</settings>

--- a/src/test/projects/http-download/pom.xml
+++ b/src/test/projects/http-download/pom.xml
@@ -42,7 +42,7 @@
               <goal>list</goal>
             </goals>
             <configuration>
-              <url>http://repo1.maven.org/maven2/commons-dbutils/commons-dbutils</url>
+              <url>https://repo1.maven.org/maven2/commons-dbutils/commons-dbutils</url>
             </configuration>
           </execution>
 
@@ -54,7 +54,7 @@
               <goal>download-single</goal>
             </goals>
             <configuration>
-              <url>http://repo1.maven.org/maven2/commons-dbutils/commons-dbutils/1.1</url>
+              <url>https://repo1.maven.org/maven2/commons-dbutils/commons-dbutils/1.1</url>
               <fromFile>commons-dbutils-1.1-sources.jar</fromFile>
               <toDir>${downloadDirectory.base}</toDir>
             </configuration>
@@ -66,7 +66,7 @@
               <goal>download-single</goal>
             </goals>
             <configuration>
-              <url>http://repo1.maven.org/maven2/commons-dbutils/commons-dbutils/1.2/commons-dbutils-1.2-sources.jar</url>
+              <url>https://repo1.maven.org/maven2/commons-dbutils/commons-dbutils/1.2/commons-dbutils-1.2-sources.jar</url>
               <toDir>${downloadDirectory.base}</toDir>
             </configuration>
           </execution>
@@ -77,7 +77,7 @@
               <goal>download</goal>
             </goals>
             <configuration>
-              <url>http://repo1.maven.org/maven2/commons-dbutils/commons-dbutils</url>
+              <url>https://repo1.maven.org/maven2/commons-dbutils/commons-dbutils</url>
               <includes>1*/**</includes>
               <excludes>1.0/**, 1.2/**, 1.3/**, 1.4/**, 1.5/**, 1.6/**</excludes>
               <toDir>${downloadDirectory.base}</toDir>


### PR DESCRIPTION
In this pull request we have fix for `download` mojo executed from Apache Maven 3.6.3+ with respective test.

Reported Issue: https://github.com/mojohaus/wagon-maven-plugin/issues/39

Details:
Breaking change was introduced by following commit: https://github.com/apache/maven-wagon/commit/7d1315e47df948d8b17f5c759b20a5b3437cbff7#diff-a0742c473bc4d821caf820463c87956b67da4d07c059d5b6a631e98dd3f7f7b4R93, in which `wagon.resourceExists("commons-dbutils-1.2-bin.tar.gz.asc")` and `wagon.resourceExists("commons-dbutils-1.2-bin.tar.gz.asc/")` (with trailing slash) executed against normalized URL - `commons-dbutils-1.2-bin.tar.gz.asc` which basically returns `true` in `WagonDirectoryScanner.isDirectory` for any URL and end up in recursion where resource name (e.g.: commons-dbutils-1.2-bin.tar.gz.asc) used as directory to retrieve list of resources during `wagon.getFileList( dir )`, where trailing slash gets appended to original resource name which throw the error `Resource missing at https://repo1.maven.org/maven2/commons-dbutils/commons-dbutils/1.2/commons-dbutils-1.2-bin.tar.gz.asc/ 404 Not Found`.
