### PR TITLE
[#54] Bump wagon.api.version from 3.0.0 to 3.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
   <properties>
     <maven.api.version>3.2.5</maven.api.version>
     <mojo.java.target>8</mojo.java.target>
-    <wagon.api.version>3.0.0</wagon.api.version>
+    <wagon.api.version>3.4.0</wagon.api.version>
 
     <!-- Test plugins -->
     <takari-plugin-testing.version>2.9.2</takari-plugin-testing.version>


### PR DESCRIPTION
fixes #54 

Not updating to 3.5.x for now, because they require a way more recent version of Maven. There's no table, but this should support Maven 3.6.3 and newer.